### PR TITLE
Fix build warning

### DIFF
--- a/crates/csharp/src/lib.rs
+++ b/crates/csharp/src/lib.rs
@@ -1512,7 +1512,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 }
             }
 
-            Instruction::Return { amt, func } => match func.results.len() {
+            Instruction::Return { amt: _, func } => match func.results.len() {
                 0 => (),
                 1 => uwriteln!(self.src, "return {};", operands[0]),
                 _ => {


### PR DESCRIPTION
Tiny tweak to avoid the warning:

```
warning: unused variable: `amt`
    --> crates/csharp/src/lib.rs:1515:35
     |
1515 |             Instruction::Return { amt, func } => match func.results.len() {
     |                                   ^^^ help: try ignoring the field: `amt: _`
     |
     = note: `#[warn(unused_variables)]` on by default
```

... as seen in the build at https://github.com/bytecodealliance/wit-bindgen/actions/runs/6714890565/job/18248780257?pr=718#step:6:362